### PR TITLE
fix: separate start-time validation from Go codegen via hidden def

### DIFF
--- a/evaluationlog.cue
+++ b/evaluationlog.cue
@@ -27,6 +27,18 @@ package gemara
 	"assessment-logs": [...{
 		requirement: "reference-id": (control."reference-id")
 	}]
+	// Require start timestamp on assessments that actually executed
+	"assessment-logs": [#_AssessmentLogStrict, ...#_AssessmentLogStrict]
+}
+
+// _AssessmentLogStrict layers the "start required unless unexecuted" rule on top of #AssessmentLog
+#_AssessmentLogStrict: {
+	@go(-)
+} & #AssessmentLog & {
+	result: #Result
+	if result != "Not Run" && result != "Unknown" && result != "Not Applicable" {
+		start: #Datetime
+	}
 }
 
 // AssessmentLog contains the results of executing a single assessment procedure for a control requirement.
@@ -50,9 +62,6 @@ package gemara
 	// Start is the timestamp when the assessment began.
 	// Assessments that never executed have no start time to record.
 	start?: #Datetime
-	if result != "Not Run" && result != "Unknown" && result != "Not Applicable" {
-		start: #Datetime
-	}
 
 	// End is the timestamp when the assessment concluded.
 	end?: #Datetime

--- a/test/compat_test.go
+++ b/test/compat_test.go
@@ -161,6 +161,8 @@ func relaxForSubsume(content string) string {
 	}
 	result := strings.Join(lines, "\n")
 
+	result = stripHiddenDefBlocks(result)
+
 	result = strings.Replace(result,
 		`#Datetime: time.Format("2006-01-02T15:04:05Z07:00")`,
 		`#Datetime: string`, 1)
@@ -173,6 +175,95 @@ func relaxForSubsume(content string) string {
 	}
 
 	return result
+}
+
+// stripHiddenDefBlocks removes hidden definition blocks (#_Foo: { ... }) and
+// collapses references to them back to their underlying public type. Hidden
+// definitions are validation-only wrappers (marked @go(-)) whose structural
+// shape causes cross-context subsumption false positives — the same class of
+// noise as time.Format and list.Contains.
+func stripHiddenDefBlocks(content string) string {
+	hiddenDefs := findHiddenDefs(content)
+
+	var out []string
+	lines := strings.Split(content, "\n")
+	i := 0
+	for i < len(lines) {
+		trimmed := strings.TrimSpace(lines[i])
+
+		if strings.HasPrefix(trimmed, "#_") && strings.Contains(trimmed, ":") {
+			defName := strings.TrimSpace(strings.SplitN(trimmed, ":", 2)[0])
+			if _, ok := hiddenDefs[defName]; ok {
+				for len(out) > 0 && strings.HasPrefix(strings.TrimSpace(out[len(out)-1]), "//") {
+					out = out[:len(out)-1]
+				}
+				depth := 0
+				for i < len(lines) {
+					code := strings.TrimSpace(lines[i])
+					if !strings.HasPrefix(code, "//") {
+						for _, ch := range code {
+							if ch == '{' {
+								depth++
+							} else if ch == '}' {
+								depth--
+							}
+						}
+					}
+					i++
+					if depth <= 0 {
+						break
+					}
+				}
+				continue
+			}
+		}
+
+		out = append(out, lines[i])
+		i++
+	}
+	result := strings.Join(out, "\n")
+
+	for name, base := range hiddenDefs {
+		result = strings.ReplaceAll(result, name, base)
+	}
+	return result
+}
+
+// findHiddenDefs scans for #_Foo: { @go(-) } & #Bar patterns and returns
+// a map from hidden name to underlying public type.
+func findHiddenDefs(content string) map[string]string {
+	defs := make(map[string]string)
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "#_") || !strings.Contains(trimmed, ":") {
+			continue
+		}
+		name := strings.TrimSpace(strings.SplitN(trimmed, ":", 2)[0])
+		depth := 0
+		for j := i; j < len(lines); j++ {
+			for _, ch := range lines[j] {
+				if ch == '{' {
+					depth++
+				} else if ch == '}' {
+					depth--
+				}
+			}
+			if idx := strings.Index(lines[j], "& #"); idx >= 0 {
+				rest := lines[j][idx+2:]
+				parts := strings.Fields(rest)
+				if len(parts) > 0 {
+					base := strings.TrimRight(parts[0], " &{")
+					defs[name] = base
+					break
+				}
+			}
+			if depth <= 0 && j > i {
+				break
+			}
+		}
+	}
+	return defs
 }
 
 func collectStableDefs(schemaDir string) ([]string, error) {
@@ -197,7 +288,7 @@ func collectStableDefs(schemaDir string) ([]string, error) {
 		}
 		for _, line := range strings.Split(content, "\n") {
 			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "#") && strings.Contains(line, ":") {
+			if strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "#_") && strings.Contains(line, ":") {
 				def := strings.TrimSpace(strings.SplitN(line, ":", 2)[0])
 				stableDefs = append(stableDefs, def)
 			}


### PR DESCRIPTION
## Description

CUE conditionals cause IncompleteKind, preventing Go struct generation. Move the "start required when executed" guard into #_AssessmentLogStrict (marked @go(-)) and apply it at the #ControlEvaluation level, keeping #AssessmentLog clean for codegen.

Update compat test to handle hidden definition blocks: skip #_ defs in collectStableDefs and strip their structural noise in relaxForSubsume, the same treatment already applied for time.Format and list.Contains cross-context false positives.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [ ] Audit Log schema (`auditlog.cue`) changes
- [ ] Capability Catalog schema (`capabilitycatalog.cue`) changes
- [ ] Control Catalog schema (`controlcatalog.cue`) changes
- [ ] Enforcement Log schema (`enforcementlog.cue`) changes
- [X] Evaluation Log schema (`evaluationlog.cue`) changes
- [ ] Guidance Catalog schema (`guidancecatalog.cue`) changes
- [ ] Mapping Document schema (`mappingdocument.cue`) changes
- [ ] Policy Document schema (`policy.cue`) changes
- [ ] Principle Catalog schema (`principlecatalog.cue`) changes
- [ ] Risk Catalog schema (`riskcatalog.cue`) changes
- [ ] Threat Catalog schema (`threatcatalog.cue`) changes
- [ ] Vector Catalog schema (`vectorcatalog.cue`) changes
- [ ] Other

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->



 ---

## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [X] This PR has content that was created with AI assistance. 
   - [X]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [X] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.
